### PR TITLE
Colon can be used instead of the pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function ddmd_ruby (state, silent) {
         break;
       }
 
-    } else if (state.src.charCodeAt(state.pos) === 0x7C/* | */ 
+    } else if ((state.src.charCodeAt(state.pos) === 0x7C/* | */ || state.src.charCodeAt(state.pos) === 0x3A/* : */)
       && state.src.charCodeAt(state.pos - 1) !== 0x5C/* \ */) {
       devPos = state.pos;
     }
@@ -56,7 +56,7 @@ function ddmd_ruby (state, silent) {
   rubyText = state.src.slice(devPos + 1, closePos);
 
   baseArray = baseText.split('');
-  rubyArray = rubyText.split('|');
+  rubyArray = rubyText.split(/\||\:/);
 
   if (baseArray.length === rubyArray.length) {
 


### PR DESCRIPTION
This pull request allows ruby tags to be generated in tables, or in some other context where the pipeline can be ambiguous.
For example, this code:

```
The pipeline still works {here|yay}

| column 1 | column 2 |
| - | - |
| {ruby|rt} | cell |
| {ruby:rt} | cell |
```

can render in

![markdownitruby-pipeline](https://user-images.githubusercontent.com/64315564/108627550-7a222680-7456-11eb-8ca4-400f95e3a538.png)
