### PR TITLE
fix: rp tokens breaking other rules

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -114,7 +114,7 @@ function ddmd_ruby (state, silent) {
       
       if (shouldOutputRp) {
         // Generate opening rp token
-        token = state.push('rp_open', 'rp', 1);
+        token = state.push('rp_open', 'rp', 0);
         token.content = rpOpen;
         token.markup = rpOpen;
       }
@@ -125,7 +125,7 @@ function ddmd_ruby (state, silent) {
       
       if (shouldOutputRp) {
         // Generate closing rp token
-        token = state.push('rp_close', 'rp', 1);
+        token = state.push('rp_close', 'rp', 0);
         token.content = rpClose;
         token.markup = rpClose;
       }
@@ -145,7 +145,7 @@ function ddmd_ruby (state, silent) {
 
     if (shouldOutputRp) {
       // Generate opening rp token
-      token = state.push('rp_open', 'rp', 1);
+      token = state.push('rp_open', 'rp', 0);
       token.content = rpOpen;
       token.markup = rpOpen;
     }
@@ -165,7 +165,7 @@ function ddmd_ruby (state, silent) {
 
     if (shouldOutputRp) {
       // Generate closing rp token
-      token = state.push('rp_close', 'rp', 1);
+      token = state.push('rp_close', 'rp', 0);
       token.content = rpClose;
       token.markup = rpClose;
     }

--- a/index.mjs
+++ b/index.mjs
@@ -112,7 +112,7 @@ function ddmd_ruby (state, silent) {
       
       if (shouldOutputRp) {
         // Generate opening rp token
-        token = state.push('rp_open', 'rp', 1);
+        token = state.push('rp_open', 'rp', 0);
         token.content = rpOpen;
         token.markup = rpOpen;
       }
@@ -123,7 +123,7 @@ function ddmd_ruby (state, silent) {
       
       if (shouldOutputRp) {
         // Generate closing rp token
-        token = state.push('rp_close', 'rp', 1);
+        token = state.push('rp_close', 'rp', 0);
         token.content = rpClose;
         token.markup = rpClose;
       }
@@ -143,7 +143,7 @@ function ddmd_ruby (state, silent) {
 
     if (shouldOutputRp) {
       // Generate opening rp token
-      token = state.push('rp_open', 'rp', 1);
+      token = state.push('rp_open', 'rp', 0);
       token.content = rpOpen;
       token.markup = rpOpen;
     }
@@ -163,7 +163,7 @@ function ddmd_ruby (state, silent) {
 
     if (shouldOutputRp) {
       // Generate closing rp token
-      token = state.push('rp_close', 'rp', 1);
+      token = state.push('rp_close', 'rp', 0);
       token.content = rpClose;
       token.markup = rpClose;
     }

--- a/test/test.cjs
+++ b/test/test.cjs
@@ -33,6 +33,15 @@ describe('markdown-it-ruby (CommonJS)', () => {
       );
     });
 
+    it('should work when surrounded with other token', () => {
+      const mdWithRp = new MarkdownIt().use(rubyPlugin, { rp: ['(', ')'] });
+      const result = mdWithRp.render('*{漢字|かんじ}*');
+      assert.strictEqual(
+        result.trim(),
+        '<p><em><ruby>漢字<rp>(</rp><rt>かんじ</rt><rp>)</rp></ruby></em></p>'
+      );
+    });
+
     it('should not add rp elements when rp option is empty strings', () => {
       const mdWithEmptyRp = new MarkdownIt().use(rubyPlugin, { rp: ['', ''] });
       const result = mdWithEmptyRp.render('{漢字|かんじ}');

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -38,6 +38,15 @@ describe('markdown-it-ruby (ESM)', () => {
       );
     });
 
+    it('should work when surrounded with other token', () => {
+      const mdWithRp = new MarkdownIt().use(rubyPlugin, { rp: ['(', ')'] });
+      const result = mdWithRp.render('*{漢字|かんじ}*');
+      assert.strictEqual(
+        result.trim(),
+        '<p><em><ruby>漢字<rp>(</rp><rt>かんじ</rt><rp>)</rp></ruby></em></p>'
+      );
+    });
+
     it('should not add rp elements when rp option is empty strings', () => {
       const mdWithEmptyRp = new MarkdownIt().use(rubyPlugin, { rp: ['', ''] });
       const result = mdWithEmptyRp.render('{漢字|かんじ}');


### PR DESCRIPTION
When using `rp` option, other inline rules used around the ruby text, including builtin ones, are breaking. This PR fixes the problem. I've also included a test that fails with version `1.1.1` and is fixed by this PR.

Thank you for the plugin and for reviewing the changes!